### PR TITLE
Fix TypeScript error in Turnstile ref type

### DIFF
--- a/src/app/xmas/register/registration-form.tsx
+++ b/src/app/xmas/register/registration-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Turnstile } from "@marsidev/react-turnstile";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { useState, useRef } from "react";
 import { env } from "~/env";
 import { submitRegistration } from "./actions";
@@ -12,7 +12,7 @@ export function RegistrationForm() {
     message: string;
   } | null>(null);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
-  const turnstileRef = useRef<any>(null);
+  const turnstileRef = useRef<TurnstileInstance | null>(null);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();


### PR DESCRIPTION
Import TurnstileInstance type from @marsidev/react-turnstile and properly type the ref as TurnstileInstance | null instead of any.

Fixes deployment error:
Type 'RefObject<{ reset: () => void; } | null>' is not assignable to type 'Ref<TurnstileInstance | undefined> | undefined'

🤖 Generated with [Claude Code](https://claude.com/claude-code)