### PR TITLE
Add Bally Bow and Arrow (1975) pinball machine

### DIFF
--- a/src/data/machines.ts
+++ b/src/data/machines.ts
@@ -193,6 +193,14 @@ export const machines: Machine[] = [
     ipdbUrl: "https://www.ipdb.org/machine.cgi?id=6354",
   },
   {
+    name: "Bow and Arrow",
+    manufacturer: "Bally",
+    year: 1975,
+    rating: "7.6/10",
+    ipdbId: "4770",
+    ipdbUrl: "https://www.ipdb.org/machine.cgi?id=4770",
+  },
+  {
     name: "Demolition Man",
     manufacturer: "Williams",
     year: 1994,


### PR DESCRIPTION
Added Bow and Arrow by Bally from 1975 with IPDB rating of 7.6/10 to the machine inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)