### PR TITLE
Add conditional admin link to XMAS and players page footers

### DIFF
--- a/src/app/xmas/admin-link.tsx
+++ b/src/app/xmas/admin-link.tsx
@@ -1,0 +1,18 @@
+import { checkAdminAuth } from "./admin/login-actions";
+
+export async function AdminLink() {
+  const isAuthenticated = await checkAdminAuth();
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <a
+      href="/xmas/admin"
+      className="text-purple-400 hover:text-purple-200 underline"
+    >
+      → Admin Panel
+    </a>
+  );
+}

--- a/src/app/xmas/page.tsx
+++ b/src/app/xmas/page.tsx
@@ -1,5 +1,6 @@
 import { and, isNotNull, isNull } from "drizzle-orm";
 import type { Metadata } from "next";
+import { AdminLink } from "./admin-link";
 import { db } from "~/db";
 import { registrations } from "~/db/schema";
 
@@ -729,6 +730,9 @@ export default async function Xmas2025() {
               Slack
             </a>
           </p>
+          <div className="mt-4">
+            <AdminLink />
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/xmas/players/page.tsx
+++ b/src/app/xmas/players/page.tsx
@@ -1,5 +1,6 @@
 import { and, isNotNull, isNull } from "drizzle-orm";
 import type { Metadata } from "next";
+import { AdminLink } from "../admin-link";
 import { db } from "~/db";
 import { registrations } from "~/db/schema";
 
@@ -148,13 +149,18 @@ export default async function PlayersPage() {
         </div>
 
         {/* Back Link */}
-        <div className="mt-8 text-center">
-          <a
-            href="/xmas"
-            className="text-cyan-400 hover:text-cyan-200 underline"
-          >
-            ← Back to tournament information
-          </a>
+        <div className="mt-8 text-center space-y-2">
+          <div>
+            <a
+              href="/xmas"
+              className="text-cyan-400 hover:text-cyan-200 underline"
+            >
+              ← Back to tournament information
+            </a>
+          </div>
+          <div>
+            <AdminLink />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Created a reusable AdminLink server component that checks for valid admin authentication cookie and conditionally renders a link to the admin panel. Added this component to the footers of both /xmas and /xmas/players pages.

- New component: src/app/xmas/admin-link.tsx
- Uses checkAdminAuth() to verify admin cookie
- Only displays when user is authenticated as admin
- Styled with purple color to match admin theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)