### PR TITLE
Add Slack notification for new XMAS tournament registrations

### DIFF
--- a/src/app/xmas/register/slack.ts
+++ b/src/app/xmas/register/slack.ts
@@ -1,0 +1,112 @@
+import { env } from "~/env";
+
+interface RegistrationData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  ifpaNumber: string | null;
+  mainTournament: boolean;
+  warmupTournament: boolean;
+  sideTournament: boolean;
+  autoVerified: boolean;
+  registrationCount: number;
+}
+
+/**
+ * Sends a notification to Slack when a new registration is received.
+ * This function is non-blocking and will not throw errors.
+ * If Slack webhook is not configured, it silently returns.
+ */
+export async function sendSlackNotification(
+  data: RegistrationData,
+): Promise<void> {
+  try {
+    // Skip if Slack webhook is not configured
+    if (!env.SLACK_WEBHOOK_URL) {
+      console.log("Slack webhook not configured, skipping notification");
+      return;
+    }
+
+    // Build tournament list
+    const tournaments: string[] = [];
+    if (data.mainTournament) tournaments.push("Main Tournament (Saturday)");
+    if (data.warmupTournament) tournaments.push("Warmup Tournament (Friday)");
+    if (data.sideTournament)
+      tournaments.push("Side Tournament (Saturday evening)");
+
+    // Format the Slack message
+    const message = {
+      text: "New XMAS Tournament Registration",
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: "🎄 New XMAS Tournament Registration",
+            emoji: true,
+          },
+        },
+        {
+          type: "section",
+          fields: [
+            {
+              type: "mrkdwn",
+              text: `*Name:*\n${data.firstName} ${data.lastName}`,
+            },
+            {
+              type: "mrkdwn",
+              text: `*Email:*\n${data.email}`,
+            },
+            {
+              type: "mrkdwn",
+              text: `*Phone:*\n${data.phone}`,
+            },
+            {
+              type: "mrkdwn",
+              text: `*IFPA #:*\n${data.ifpaNumber || "Not provided"}`,
+            },
+          ],
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Tournaments:*\n${tournaments.map((t) => `• ${t}`).join("\n")}`,
+          },
+        },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: `${data.autoVerified ? "✅ Auto-verified" : "⏳ Awaiting verification"} | Registration #${data.registrationCount}`,
+            },
+          ],
+        },
+      ],
+    };
+
+    // Send to Slack
+    const response = await fetch(env.SLACK_WEBHOOK_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(message),
+    });
+
+    if (!response.ok) {
+      console.error(
+        "Failed to send Slack notification:",
+        response.status,
+        response.statusText,
+      );
+    } else {
+      console.log("Slack notification sent successfully");
+    }
+  } catch (error) {
+    // Log error but don't throw - registration should always succeed
+    console.error("Error sending Slack notification:", error);
+  }
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,6 +14,7 @@ export const env = createEnv({
     TURNSTILE_SECRET_KEY: z.string().min(1),
     AUTO_VERIFY_LIMIT: z.coerce.number().int().positive().default(50),
     ADMIN_PASSWORD: z.string().min(8),
+    SLACK_WEBHOOK_URL: z.string().url().optional(),
   },
 
   /**
@@ -36,6 +37,7 @@ export const env = createEnv({
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
     AUTO_VERIFY_LIMIT: process.env.AUTO_VERIFY_LIMIT,
     ADMIN_PASSWORD: process.env.ADMIN_PASSWORD,
+    SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially


### PR DESCRIPTION
This commit adds integration with Slack to send notifications when new tournament registrations are submitted. The implementation is designed to be non-blocking and fail-safe, ensuring registrations succeed even if the Slack integration encounters errors.

Changes:
- Add SLACK_WEBHOOK_URL environment variable (optional)
- Create sendSlackNotification helper with comprehensive error handling
- Integrate Slack notification into registration submission flow
- Format messages with Slack blocks for better readability
- Include tournament selections, participant info, and verification status

The Slack notification is completely optional - if the webhook URL is not configured, the system silently skips the notification without affecting registration functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)